### PR TITLE
Fix instructions not taking over the entire card

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -33,10 +33,7 @@ let domUpdates = {
         <div class='recipe-card' id=${recipe.id}>
           <h3>${name}</h3>
           <div class='card-photo-container'>
-            <img src=${recipe.image} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
-            <div class='text'>
-              <div>Click for Instructions</div>
-            </div>
+            <img src=${recipe.image} id=${recipe.id} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
           </div>
           <h4>${recipe.tags[0]}</h4>
           <img src='../images/add-to-cook-queue-2.png' alt="add to cook queue icon" class='card-silverware-icon'>
@@ -58,9 +55,6 @@ let domUpdates = {
           <h3>${name}</h3>
           <div class='card-photo-container'>
             <img src=${recipe.image} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
-            <div class='text'>
-              <div>Click for Instructions</div>
-            </div>
           </div>
           <h4>${recipe.tags[0]}</h4>
           <img src='../images/add-to-cook-queue-2.png' alt="add to cook queue icon" class='card-silverware-icon'>
@@ -82,10 +76,7 @@ let domUpdates = {
         <div class='recipe-card' id=${recipe.id}>
           <h3>${name}</h3>
           <div class='card-photo-container'>
-            <img src=${recipe.image} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
-            <div class='text'>
-              <div>Click for Instructions</div>
-            </div>
+            <img src='${recipe.image}' id=${recipe.id} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
           </div>
           <h4>${recipe.tags[0]}</h4>
           <img src='../images/add-to-cook-queue-2.png' alt="add to cook queue icon" class='card-silverware-icon'>
@@ -108,10 +99,7 @@ let domUpdates = {
         <div class='recipe-card' id=${recipe.id}>
           <h3>${name}</h3>
           <div class='card-photo-container'>
-            <img src=${recipe.image} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
-            <div class='text'>
-              <div>Click for Instructions</div>
-            </div>
+            <img src='${recipe.image}' id=${recipe.id} class='card-photo-preview' alt='${recipe.name} recipe' title='${recipe.name} recipe'>
           </div>
           <h4>${recipe.tags[0]}</h4>
           <img src='../images/add-to-cook-queue-2.png' alt="add to cook queue icon" class='card-silverware-icon'>

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -107,7 +107,8 @@ function getTagsFromRecipeData() {
 }
 
 function clickRecipeCard(event) {
-  let eventTarget = event.target.closest('.recipe-card');
+  let eventTarget = event.target.closest('.card-photo-preview');
+  console.log('event target', eventTarget)
   if (eventTarget) {
     const targetId = parseInt(eventTarget.id);
     const foundRecipe = cookbook.cookbook.find(


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

- Fix issue with the instructions taking over the entire card, not allowing you to click other parts of the card. 

## Issues Closed


## Type of change
Check the relevant option:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (clean up code)

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Click the recipe card to make sure instructions can only be clicked by the image